### PR TITLE
Fix: Diff for rules needs extra #=- added by atlassian/go-vtm

### DIFF
--- a/resource_rule.go
+++ b/resource_rule.go
@@ -38,7 +38,7 @@ func resourceRule() *schema.Resource {
 }
 
 func compareWithNoteContent(k, old, new string, d *schema.ResourceData) bool {
-	newContent := fmt.Sprintf("#=-%v\n", d.Get("note")) + string(new)
+	newContent := fmt.Sprintf("#=-%v\n#=-\n", d.Get("note")) + string(new)
 	log.Printf(old, newContent)
 	return hashString(old) == hashString(newContent)
 }


### PR DESCRIPTION
Rules are showing as always changed when running `terraform plan`. It seems it's down to the extra `#=-` added for notes in here: https://github.com/atlassian/go-vtm/blob/master/file.go#L18.
