### PR TITLE
Adding alt_certificates capability to vservers

### DIFF
--- a/resource_virtual_server.go
+++ b/resource_virtual_server.go
@@ -169,6 +169,12 @@ func resourceVirtualServer() *schema.Resource {
 				Default:  "",
 			},
 
+                        "ssl_server_cert_alt_certificates": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Optional: true,
+                                Default:  "",
+                        },
+
 			"ssl_server_cert_host_mapping": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -256,6 +262,7 @@ func resourceVirtualServerRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ssl_add_http_headers", bool(*r.SSL.AddHTTPHeaders))
 	d.Set("ssl_decrypt", bool(*r.Basic.SSLDecrypt))
 	d.Set("ssl_server_cert_default", string(*r.SSL.ServerCertDefault))
+        d.Set("ssl_server_cert_alt_certificates", string(*r.SSL.ServerCertAltCertificates))
 	d.Set("ssl_server_cert_host_mapping", flattenServerCertHostMappingTable(*r.SSL.ServerCertHostMapping))
 	d.Set("syslog_format", string(*r.Syslog.Format))
 	d.Set("web_cache_enabled", bool(*r.WebCache.Enabled))
@@ -322,6 +329,7 @@ func resourceVirtualServerSet(d *schema.ResourceData, meta interface{}) error {
 	setBool(&r.SSL.AddHTTPHeaders, d, "ssl_add_http_headers")
 	setBool(&r.Basic.SSLDecrypt, d, "ssl_decrypt")
 	setString(&r.SSL.ServerCertDefault, d, "ssl_server_cert_default")
+        setString(&r.SSL.ServerCertAltCertificates, d, "ssl_server_cert_alt_certificates")
 	setServerCertHostMappingTable(&r.SSL.ServerCertHostMapping, d, "ssl_server_cert_host_mapping")
 	setString(&r.Syslog.Format, d, "syslog_format")
 	setBool(&r.WebCache.Enabled, d, "web_cache_enabled")

--- a/resource_virtual_server.go
+++ b/resource_virtual_server.go
@@ -173,7 +173,6 @@ func resourceVirtualServer() *schema.Resource {
                                 Type:          schema.TypeList,
                                 Optional:      true,
                                 Elem:          &schema.Schema{Type: schema.TypeString},
-                                PromoteSingle: true,
                         },
 
 			"ssl_server_cert_host_mapping": &schema.Schema{

--- a/resource_virtual_server.go
+++ b/resource_virtual_server.go
@@ -329,7 +329,7 @@ func resourceVirtualServerSet(d *schema.ResourceData, meta interface{}) error {
 	setBool(&r.SSL.AddHTTPHeaders, d, "ssl_add_http_headers")
 	setBool(&r.Basic.SSLDecrypt, d, "ssl_decrypt")
 	setString(&r.SSL.ServerCertDefault, d, "ssl_server_cert_default")
-        setString(&r.SSL.ServerCertAltCertificates, d, "ssl_server_cert_alt_certificates")
+        setStringList(&r.SSL.ServerCertAltCertificates, d, "ssl_server_cert_alt_certificates")
 	setServerCertHostMappingTable(&r.SSL.ServerCertHostMapping, d, "ssl_server_cert_host_mapping")
 	setString(&r.Syslog.Format, d, "syslog_format")
 	setBool(&r.WebCache.Enabled, d, "web_cache_enabled")

--- a/resource_virtual_server.go
+++ b/resource_virtual_server.go
@@ -170,9 +170,10 @@ func resourceVirtualServer() *schema.Resource {
 			},
 
                         "ssl_server_cert_alt_certificates": &schema.Schema{
-                                Type:     schema.TypeString,
-                                Optional: true,
-                                Default:  "",
+                                Type:          schema.TypeList,
+                                Optional:      true,
+                                Elem:          &schema.Schema{Type: schema.TypeString},
+                                PromoteSingle: true,
                         },
 
 			"ssl_server_cert_host_mapping": &schema.Schema{
@@ -262,7 +263,7 @@ func resourceVirtualServerRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ssl_add_http_headers", bool(*r.SSL.AddHTTPHeaders))
 	d.Set("ssl_decrypt", bool(*r.Basic.SSLDecrypt))
 	d.Set("ssl_server_cert_default", string(*r.SSL.ServerCertDefault))
-        d.Set("ssl_server_cert_alt_certificates", string(*r.SSL.ServerCertAltCertificates))
+        d.Set("ssl_server_cert_alt_certificates", []string(*r.SSL.ServerCertAltCertificates))
 	d.Set("ssl_server_cert_host_mapping", flattenServerCertHostMappingTable(*r.SSL.ServerCertHostMapping))
 	d.Set("syslog_format", string(*r.Syslog.Format))
 	d.Set("web_cache_enabled", bool(*r.WebCache.Enabled))


### PR DESCRIPTION
This adds the top-level alt_certificates to vservers, allowing vservers to have a secondary default certificate. That may, in turn, be useful for admins who wish to offer either an ECDSA or an RSA certificate to connecting clients.

Once this is done, we can add alt_certificates to the host mapping table as well.